### PR TITLE
Update inputs.py

### DIFF
--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -407,8 +407,7 @@ class Atoms(MSONable):
         self.absorbing_atom, self.center_index = get_absorbing_atom_symbol_index(absorbing_atom, struct)
         self.radius = radius
         self._cluster = self._set_cluster()
-        atom_sym = get_absorbing_atom_symbol_index(absorbing_atom, self._cluster)[0]
-        self.pot_dict = get_atom_map(self._cluster, atom_sym)
+        self.pot_dict = get_atom_map(self._cluster, self.absorbing_atom)
 
     def _set_cluster(self):
         """


### PR DESCRIPTION
Dear Pymatgen group members,
My name is Kaifeng Zheng. I'm Ph.D. student from Stony Brook University studying materials science in Anatoly Frenkel's group.

I found a small bug inside the feff.inputs module.

atom_sym = get_absorbing_atom_symbol_index(absorbing_atom, self._cluster)[0]

The argument 'absorbing_atom' is misused, which generated bugs. Based on my understanding, this "absorbing_atom" is the index of the absorbing atom in the original structure, but this sentence misused this index for the absorbing atom in the generated cluster, which should be 0.

Firstly, I think I need to change this argument to 0. However, after I scrutinize the codes, I found that this sentence is not useful, so I delete it.

Please let me know what you think.

Best regards,

Kaifeng Zheng
kaifeng.zheng@stonybrook.edu

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
